### PR TITLE
Fixbug: Using a `tf.Tensor` as a Python `bool`

### DIFF
--- a/4-Object_Detection/YOLOV3/core/common.py
+++ b/4-Object_Detection/YOLOV3/core/common.py
@@ -21,7 +21,7 @@ class BatchNormalization(tf.keras.layers.BatchNormalization):
     and `beta` will not be updated !
     """
     def call(self, x, training=False):
-        if not training:
+        if isinstance(training, bool) and training == False:
             training = tf.constant(False)
         training = tf.logical_and(training, self.trainable)
         return super().call(x, training)


### PR DESCRIPTION
I found this bug when using inference code (`python video_demo.py`).

## Environment: 
- Miniconda.
- Python 3.7.
- Install requirements from `./docs/requirements.txt`.

## Error Trace:

```
Traceback (most recent call last):
  File "video_demo.py", line 28, in <module>
    feature_maps = YOLOv3(input_layer)
  File "/mnt/DATA/TRAINING/TensorFlow2.0-Examples/4-Object_Detection/YOLOV3/core/yolov3.py", line 28, in YOLOv3
    route_1, route_2, conv = backbone.darknet53(input_layer)
  File "/mnt/DATA/TRAINING/TensorFlow2.0-Examples/4-Object_Detection/YOLOV3/core/backbone.py", line 20, in darknet53
    input_data = common.convolutional(input_data, (3, 3,  3,  32))
  File "/mnt/DATA/TRAINING/TensorFlow2.0-Examples/4-Object_Detection/YOLOV3/core/common.py", line 43, in convolutional
    if bn: conv = BatchNormalization()(conv)
  File "/home/ironman/miniconda3/envs/tf2/lib/python3.7/site-packages/tensorflow/python/keras/engine/base_layer.py", line 662, in __call__
    outputs = call_fn(inputs, *args, **kwargs)
  File "/home/ironman/miniconda3/envs/tf2/lib/python3.7/site-packages/tensorflow/python/autograph/impl/api.py", line 169, in wrapper
    raise e.ag_error_metadata.to_exception(type(e))
TypeError: in converted code:

    /mnt/DATA/TRAINING/TensorFlow2.0-Examples/4-Object_Detection/YOLOV3/core/common.py:24 call
        if not training:
    /home/ironman/miniconda3/envs/tf2/lib/python3.7/site-packages/tensorflow/python/framework/ops.py:698 __bool__
        raise TypeError("Using a `tf.Tensor` as a Python `bool` is not allowed. "

    TypeError: Using a `tf.Tensor` as a Python `bool` is not allowed. Use `if t is not None:` instead of `if t:` to test if a tensor is defined, and use TensorFlow ops such as tf.cond to execute subgraphs conditioned on the value of a tensor.
```

